### PR TITLE
Fix route conflict: Remove duplicate destinations.edit route definition

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -22,7 +22,7 @@ cmd = "npm run production"
 cmd = "php artisan config:cache"
 
 [[build.steps]]
-cmd = "php artisan route:cache"
+cmd = "php artisan route:cache --verbose"
 
 [[build.steps]]
 cmd = "php artisan view:cache"

--- a/routes/web.php
+++ b/routes/web.php
@@ -111,8 +111,6 @@ Route::get('/stripe', [
 
 
 
-Route::get('destinations.edit/{destinations}', 'DestinationsController@edit')->name('destinations.edit');
-
 Route::get('/cart/{id}/remove', 'CartController@removeItem')->name('cart.remove');
 
 


### PR DESCRIPTION
- Route::resource already provides destinations.edit route
- Duplicate manual route definition caused serialization conflict
- This resolves Railway deployment LogicException error